### PR TITLE
Exclude spacingbeforethen rule

### DIFF
--- a/phpcs/Sincos/ruleset.xml
+++ b/phpcs/Sincos/ruleset.xml
@@ -49,7 +49,6 @@
         <exclude name="Squiz.Commenting.FileComment.SubpackageTagOrder"/>
         <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
         <exclude name="Squiz.Commenting.FunctionComment.MissingReturn"/>
-        <exclude name="Squiz.Commenting.FunctionCommentThrowTag.Missing"/>
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
         <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
@@ -57,8 +56,10 @@
         <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
         <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
         <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn"/>
+        <exclude name="Squiz.Commenting.FunctionCommentThrowTag.Missing"/>
         <exclude name="Squiz.Commenting.LongConditionClosingComment.Missing"/>
         <exclude name="Squiz.Commenting.VariableComment.Missing"/>
+        <exclude name="Squiz.ControlStructures.InlineIfDeclaration.SpacingBeforeThen"/>
         <exclude name="Squiz.Files.FileExtension.ClassFound"/>
         <exclude name="Squiz.Formatting.OperatorBracket.MissingBrackets"/>
         <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.NewlineBeforeOpenBrace"/>


### PR DESCRIPTION
This will allow us to do multiline shorthand ternary stuff like this:

```php
return $foo
    ?: $bar
    ?: $baz;
```